### PR TITLE
Proposed fix to reported issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ gulp-vows takes an options object with the following options
 ### options.verbose
 *boolean*: Verbose output. (unstable)
 
+### options.errorOnFailedTests
+*boolean*: Throw an error if any tests fail
+
 ### options.coverage
 @todo: to be implemented
 

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const PLUGIN_NAME = 'gulp-vows';
 var args = {
   reporter: require('vows/lib/vows/reporters/dot-matrix'),
   verbose: false,
+  errorOnFailedTests: false,
   shuffle: false
 };
 
@@ -64,6 +65,9 @@ function parseArguments(_args) {
 
   if (typeof _args.shuffle === "boolean")
     args.shuffle = _args.shuffle;
+
+  if (typeof _args.errorOnFailedTests === "boolean")
+    args.errorOnFailedTests = _args.errorOnFailedTests;
 
   // // nocolor
   // if (typeof _args.nocolor === "boolean")
@@ -212,7 +216,12 @@ function gulpVows(gOptions) {
 
       that.push();
 
-      return cb();
+      if(status > 0 && args.errorOnFailedTests) {
+          return cb(new gutil.PluginError('gulp-vow', 'Tests failed'));
+      }
+      else {
+          return cb();
+      }
     }
 
   });


### PR DESCRIPTION
Hi, 

As I hinted in the issue I reported to you a couple of weeks ago, I was having some trouble informing my CI system that tests where broken when using your excellent gulp-vows plugin.

I had a stab at modifying the code, and it solved it from my end. So I done a little patch, which includes a argument that will allow people to control if they want to throw an error when tests fail or not.

I haven't changed the default behaviour, to you have to explicitly enable it.

All the best,
Daniel 
